### PR TITLE
[1.0] Add actions (buttons) to attachments

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -82,6 +82,7 @@ class SlackWebhookChannel
     {
         return collect($message->attachments)->map(function ($attachment) use ($message) {
             return array_filter([
+                'actions' => $attachment->actions,
                 'author_icon' => $attachment->authorIcon,
                 'author_link' => $attachment->authorLink,
                 'author_name' => $attachment->authorName,

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -79,6 +79,13 @@ class SlackAttachment
     public $thumbUrl;
 
     /**
+     * The attachment's actions.
+     *
+     * @var array
+     */
+    public $actions = [];
+
+    /**
      * The attachment author's name.
      *
      * @var string
@@ -259,6 +266,25 @@ class SlackAttachment
     public function thumb($url)
     {
         $this->thumbUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * Add an action (button) under the attachment.
+     *
+     * @param string $title
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function action($title, $url)
+    {
+        $this->actions[] = [
+            'type' => 'button',
+            'text' => $title,
+            'url' => $url,
+        ];
 
         return $this;
     }

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -273,10 +273,9 @@ class SlackAttachment
     /**
      * Add an action (button) under the attachment.
      *
-     * @param string $title
-     * @param string $url
-     * @param string $style
-     *
+     * @param  string  $title
+     * @param  string  $url
+     * @param  string  $style
      * @return $this
      */
     public function action($title, $url, $style = '')

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -275,15 +275,17 @@ class SlackAttachment
      *
      * @param string $title
      * @param string $url
+     * @param string $style
      *
      * @return $this
      */
-    public function action($title, $url)
+    public function action($title, $url, $style = '')
     {
         $this->actions[] = [
             'type' => 'button',
             'text' => $title,
             'url' => $url,
+            'style' => $style,
         ];
 
         return $this;


### PR DESCRIPTION
This PR adds the option to show buttons, called actions, under attachments in Slack notifications.

Slack API: https://api.slack.com/docs/message-attachments#action_fields

How it could look:
![afbeelding](https://user-images.githubusercontent.com/1116853/49649717-3df77c80-fa2a-11e8-9c13-dd5213846e49.png)

How this would look in the notification class:

```php
public function toSlack($notifiable): SlackMessage
    {
        return (new SlackMessage())
            ->error()
            ->attachment(function (SlackAttachment $attachment) {
                $attachment
                    ->title('🚨 '.$this->site->name.' lijkt offline.')
                    ->content('URL: '.$this->url)
                    ->action('🔎  Monitor openen', url('/'));
            });
    }
```