### PR TITLE
[5.8] Use Facade::resolved() before extending channel

### DIFF
--- a/src/SlackChannelServiceProvider.php
+++ b/src/SlackChannelServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Notifications;
 
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Facades\Notification;
 
 class SlackChannelServiceProvider extends ServiceProvider
@@ -15,8 +16,10 @@ class SlackChannelServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Notification::extend('slack', function ($app) {
-            return new Channels\SlackWebhookChannel(new HttpClient);
+        Notification::resolved(function (ChannelManager $service) {
+            $service->extend('slack', function ($app) {
+                return new Channels\SlackWebhookChannel(new HttpClient);
+            });
         });
     }
 }


### PR DESCRIPTION
This allow slack notification to only be loaded when/if the notification is resolved. Based on PR made to laravel/framework#26824