### PR TITLE
Fix Notification service resolution in provider

### DIFF
--- a/src/SlackChannelServiceProvider.php
+++ b/src/SlackChannelServiceProvider.php
@@ -9,11 +9,11 @@ use Illuminate\Support\Facades\Notification;
 class SlackChannelServiceProvider extends ServiceProvider
 {
     /**
-     * Register the service provider.
+     * Boot the service provider.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
         Notification::extend('slack', function ($app) {
             return new Channels\SlackWebhookChannel(new HttpClient);


### PR DESCRIPTION
`ChannelManager` should be resolved not in `register()` but in `boot()`.
**It will break application bootstrap** if `ChannelManager` is extended and the original `Illuminate\Notifications\NotificationServiceProvider` is replaced by `App\Providers\NotificationServiceProvider`.

```
Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Support\Manager
```

Related: https://github.com/laravel/nexmo-notification-channel/pull/5