### PR TITLE
Add block kit support to attachments

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
+use Illuminate\Notifications\Messages\SlackAttachmentBlock;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
 
 class SlackWebhookChannel
@@ -89,6 +90,7 @@ class SlackWebhookChannel
                 'color' => $attachment->color ?: $message->color(),
                 'fallback' => $attachment->fallback,
                 'fields' => $this->fields($attachment),
+                'blocks' => $this->blocks($attachment),
                 'footer' => $attachment->footer,
                 'footer_icon' => $attachment->footerIcon,
                 'image_url' => $attachment->imageUrl,
@@ -117,6 +119,19 @@ class SlackWebhookChannel
             }
 
             return ['title' => $key, 'value' => $value, 'short' => true];
+        })->values()->all();
+    }
+
+    /**
+     * Format the attachment's blocks.
+     *
+     * @param  \Illuminate\Notifications\Messages\SlackAttachment  $attachment
+     * @return array
+     */
+    protected function blocks(SlackAttachment $attachment)
+    {
+        return collect($attachment->blocks)->map(function (SlackAttachmentBlock $value) {
+            return $value->toArray();
         })->values()->all();
     }
 }

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications\Messages;
 
+use Closure;
 use Illuminate\Support\InteractsWithTime;
 
 class SlackAttachment
@@ -56,6 +57,11 @@ class SlackAttachment
      * @var array
      */
     public $fields;
+
+    /**
+     * The attachment's blocks.
+     */
+    public $blocks;
 
     /**
      * The fields containing markdown.
@@ -227,6 +233,21 @@ class SlackAttachment
     public function fields(array $fields)
     {
         $this->fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Add a block to the attachment.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function block(Closure $callback)
+    {
+        $this->blocks[] = $block = new SlackAttachmentBlock;
+
+        $callback($block);
 
         return $this;
     }

--- a/src/Messages/SlackAttachmentBlock.php
+++ b/src/Messages/SlackAttachmentBlock.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class SlackAttachmentBlock
+{
+    /**
+     * The type field of the attachment block.
+     *
+     * @var string
+     */
+    public $type;
+
+    /**
+     * The text field of the attachment block.
+     *
+     * @var array
+     */
+    public $text;
+
+    /**
+     * The block ID field of the attachment block.
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The fields field of the attachment block.
+     *
+     * @var array
+     */
+    public $fields;
+
+    /**
+     * The accessory field of the attachment block.
+     *
+     * @var array
+     */
+    public $accessory;
+
+    /**
+     * The image url field of the attachment block.
+     *
+     * @var string
+     */
+    public $imageUrl;
+
+    /**
+     * The alt text field of the attachment block.
+     *
+     * @var string
+     */
+    public $altText;
+
+    /**
+     * The title field of the attachment block.
+     *
+     * @var array
+     */
+    public $title;
+
+    /**
+     * The elements field of the attachment block.
+     *
+     * @var array
+     */
+    public $elements;
+
+    /**
+     * Set the type of the block.
+     *
+     * @param  string  $type
+     * @return $this
+     */
+    public function type($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Set the text of the block.
+     *
+     * @param  array  $text
+     * @return $this
+     */
+    public function text($text)
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * Set the ID of the block.
+     *
+     * @param  string  $id
+     * @return $this
+     */
+    public function id($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Set the fields of the block.
+     *
+     * @param  array  $fields
+     * @return $this
+     */
+    public function fields($fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Set the accessory of the block.
+     *
+     * @param  array  $accessory
+     * @return $this
+     */
+    public function accessory($accessory)
+    {
+        $this->accessory = $accessory;
+
+        return $this;
+    }
+
+    /**
+     * Set the image url of the block.
+     *
+     * @param  string  $imageUrl
+     * @return $this
+     */
+    public function imageUrl($imageUrl)
+    {
+        $this->imageUrl = $imageUrl;
+
+        return $this;
+    }
+
+    /**
+     * Set the alt text of the block.
+     *
+     * @param  string  $altText
+     * @return $this
+     */
+    public function altText($altText)
+    {
+        $this->altText = $altText;
+
+        return $this;
+    }
+
+    /**
+     * Set the title of the block.
+     *
+     * @param  array  $title
+     * @return $this
+     */
+    public function title($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Set the elements of the block.
+     *
+     * @param  array  $elements
+     * @return $this
+     */
+    public function elements($elements)
+    {
+        $this->elements = $elements;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the attachment block.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_filter([
+            'type' => $this->type,
+            'text' => $this->text,
+            'block_id' => $this->id,
+            'fields' => $this->fields,
+            'accessory' => $this->accessory,
+            'image_url' => $this->imageUrl,
+            'alt_text' => $this->altText,
+            'title' => $this->title,
+            'elements' => $this->elements,
+        ]);
+    }
+}

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -60,6 +60,7 @@ class NotificationSlackChannelTest extends TestCase
             'payloadWithImageIcon' => $this->getPayloadWithImageIcon(),
             'payloadWithoutOptionalFields' => $this->getPayloadWithoutOptionalFields(),
             'payloadWithAttachmentFieldBuilder' => $this->getPayloadWithAttachmentFieldBuilder(),
+            'payloadWithAttachmentBlockBuilder' => $this->getPayloadWithAttachmentBlockBuilder(),
         ];
     }
 
@@ -190,6 +191,70 @@ class NotificationSlackChannelTest extends TestCase
             ],
         ];
     }
+
+    public function getPayloadWithAttachmentBlockBuilder()
+    {
+        return [
+            new NotificationSlackChannelWithAttachmentBlockBuilderTestNotification,
+            [
+                'json' => [
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'text' => 'Attachment Content',
+                            'title_link' => 'https://laravel.com',
+                            'blocks' => [
+                                [
+                                    'type' => 'section',
+                                    'text' => [
+                                        'type' => 'plain_text',
+                                        'text' => 'Laravel',
+                                    ],
+                                    'block_id' => 'block-one',
+                                    'fields' => [
+                                        [
+                                            'type' => 'mrkdwn',
+                                            'text' => 'Block',
+                                        ],
+                                        [
+                                            'type' => 'mrkdwn',
+                                            'text' => 'Attachments',
+                                        ],
+                                    ],
+                                    'accessory' => [
+                                        'type' => 'datepicker',
+                                    ],
+                                ],
+                                [
+                                    'type' => 'divider',
+                                ],
+                                [
+                                    'type' => 'image',
+                                    'image_url' => 'https://placekitten.com/400/600',
+                                    'alt_text' => 'A cute little kitten',
+                                    'title' => [
+                                        'type' => 'plain_text',
+                                        'text' => 'Kitten picture',
+                                    ],
+                                ],
+                                [
+                                    'type' => 'actions',
+                                    'elements' => [
+                                        'type' => 'button',
+                                        "text" => [
+                                            'type' => 'plain_text',
+                                            'text' => 'Cancel',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 }
 
 class NotificationSlackChannelTestNotifiable
@@ -285,6 +350,65 @@ class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends
                             ->title('Special powers')
                             ->content('Zonda')
                             ->long();
+                    });
+            });
+    }
+}
+
+class NotificationSlackChannelWithAttachmentBlockBuilderTestNotification extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->content('Content')
+            ->attachment(function ($attachment) {
+                $attachment->title('Laravel', 'https://laravel.com')
+                    ->content('Attachment Content')
+                    ->block(function ($attachmentBlock) {
+                        $attachmentBlock
+                            ->type('section')
+                            ->text([
+                                'type' => 'plain_text',
+                                'text' => 'Laravel',
+                            ])
+                            ->id('block-one')
+                            ->fields([
+                                [
+                                    'type' => 'mrkdwn',
+                                    'text' => 'Block',
+                                ],
+                                [
+                                    'type' => 'mrkdwn',
+                                    'text' => 'Attachments',
+                                ],
+                            ])
+                            ->accessory([
+                                'type' => 'datepicker',
+                            ]);
+                    })
+                    ->block(function ($attachmentBlock) {
+                        $attachmentBlock->type('divider');
+                    })
+                    ->block(function ($attachmentBlock) {
+                        $attachmentBlock
+                            ->type('image')
+                            ->imageUrl('https://placekitten.com/400/600')
+                            ->altText('A cute little kitten')
+                            ->title([
+                                'type' => 'plain_text',
+                                'text' => 'Kitten picture'
+                            ]);
+                    })
+                    ->block(function ($attachmentBlock) {
+                        $attachmentBlock
+                            ->type('actions')
+                            ->elements([
+                                'type' => 'button',
+                                "text" => [
+                                    'type' => 'plain_text',
+                                    'text' => 'Cancel',
+                                ],
+                            ]);
                     });
             });
     }


### PR DESCRIPTION
This PR adds the necessary functionality to add [Blocks](https://api.slack.com/changelog/2018-12-a-bric-a-brac-of-broadcasts-built-with-blocks) to Slack notifications, resolves #12 and just adding a lot of cool functionality in general.

All of the direct Block fields that appear on the [main reference page](https://api.slack.com/reference/messaging/blocks) are supported. Some of these fields accept a large variety of objects, so for these fields you will simply need to compose associative arrays that align to Slack's objects. You can see some examples of this in the test I added.