### PR TITLE
[2.0] Return Guzzle response

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -33,7 +33,7 @@ class SlackWebhookChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return \Psr\Http\Message\ResponseInterface|null
      */
     public function send($notifiable, Notification $notification)
     {

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -33,7 +33,7 @@ class SlackWebhookChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return void
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function send($notifiable, Notification $notification)
     {
@@ -41,7 +41,7 @@ class SlackWebhookChannel
             return;
         }
 
-        $this->http->post($url, $this->buildJsonPayload(
+        return $this->http->post($url, $this->buildJsonPayload(
             $notification->toSlack($notifiable)
         ));
     }


### PR DESCRIPTION
This allows the `NotificationSent` event object to have a `$response` object that we can inspect and report on using a listener for the `NotificationSent` event:

```php
// File: app/Listeners/LogNotificationSent.php

/**
 * Handle the event.
 *
 * @param  NotificationSent  $event
 * @return void
 */
public function handle(NotificationSent $event)
{
    if( $event->response instanceof ResponseInterface) {
        // ...
    }
}
```

Reference:

* The `$response` variable is something standard on the [`NotificationSent` object](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Notifications/Events/NotificationSent.php#L49) 
* The response from the sending is returned and added to the [event object here](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Notifications/NotificationSender.php#L144-L148)