### PR TITLE
[2.0] Included possibility to utilize Slack API instead of Slack webhooks

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -16,6 +16,7 @@ class SlackWebhookChannel
      * @var \GuzzleHttp\Client
      */
     protected $http;
+    protected $token;
 
     /**
      * Create a new Slack channel instance.
@@ -26,6 +27,7 @@ class SlackWebhookChannel
     public function __construct(HttpClient $http)
     {
         $this->http = $http;
+        $this->token = null;
     }
 
     /**
@@ -43,26 +45,23 @@ class SlackWebhookChannel
 
         if (substr($route, 0, 4 ) === 'xoxp') {
             $url = 'https://slack.com/api/chat.postMessage';
-            $token = $route;
+            $this->token = $route;
         } else {
             $url = $route;
-            $token = null;
         }
 
         return $this->http->post($url, $this->buildJsonPayload(
-            $notification->toSlack($notifiable),
-            $token
+            $notification->toSlack($notifiable)
         ));
     }
 
     /**
      * Build up a JSON payload for the Slack webhook.
      *
-     * @param  string  $token
      * @param  \Illuminate\Notifications\Messages\SlackMessage  $message
      * @return array
      */
-    protected function buildJsonPayload(SlackMessage $message, string $token=null)
+    protected function buildJsonPayload(SlackMessage $message)
     {
         $optionalFields = array_filter([
             'channel' => data_get($message, 'channel'),
@@ -82,10 +81,10 @@ class SlackWebhookChannel
         ];
 
 
-        if ($token) {
+        if ($this->token) {
             $payload['headers'] = [
                 'Content-type' => 'application/json',
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer '.$this->token,
             ];
         }
 

--- a/tests/api/NotificationSlackChannelAPITest.php
+++ b/tests/api/NotificationSlackChannelAPITest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Notifications;
+namespace Illuminate\Tests\Notifications\Api;
 
 use Mockery as m;
 use GuzzleHttp\Client;
@@ -11,7 +11,7 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 
-class NotificationSlackChannelTest extends TestCase
+class NotificationSlackChannelAPITest extends TestCase
 {
     /**
      * @var \Illuminate\Notifications\Channels\SlackWebhookChannel
@@ -45,7 +45,7 @@ class NotificationSlackChannelTest extends TestCase
     public function testCorrectPayloadIsSentToSlack(Notification $notification, array $payload)
     {
         $this->guzzleHttp->shouldReceive('post')->andReturnUsing(function ($argUrl, $argPayload) use ($payload) {
-            $this->assertEquals($argUrl, 'url');
+            $this->assertEquals($argUrl, 'https://slack.com/api/chat.postMessage');
             $this->assertEquals($argPayload, $payload);
         });
 
@@ -67,6 +67,10 @@ class NotificationSlackChannelTest extends TestCase
         return [
             new NotificationSlackChannelTestNotification,
             [
+                'headers' => [
+                    'Content-type' => 'application/json',
+                    'Authorization' => 'Bearer xoxp-token',
+                ],
                 'json' => [
                     'username' => 'Ghostbot',
                     'icon_emoji' => ':ghost:',
@@ -104,6 +108,10 @@ class NotificationSlackChannelTest extends TestCase
         return [
             new NotificationSlackChannelTestNotificationWithImageIcon,
             [
+                'headers' => [
+                    'Content-type' => 'application/json',
+                    'Authorization' => 'Bearer xoxp-token',
+                ],
                 'json' => [
                     'username' => 'Ghostbot',
                     'icon_url' => 'http://example.com/image.png',
@@ -138,6 +146,10 @@ class NotificationSlackChannelTest extends TestCase
         return [
             new NotificationSlackChannelWithoutOptionalFieldsTestNotification,
             [
+                'headers' => [
+                    'Content-type' => 'application/json',
+                    'Authorization' => 'Bearer xoxp-token',
+                ],
                 'json' => [
                     'text' => 'Content',
                     'attachments' => [
@@ -164,6 +176,10 @@ class NotificationSlackChannelTest extends TestCase
         return [
             new NotificationSlackChannelWithAttachmentFieldBuilderTestNotification,
             [
+                'headers' => [
+                    'Content-type' => 'application/json',
+                    'Authorization' => 'Bearer xoxp-token',
+                ],
                 'json' => [
                     'text' => 'Content',
                     'attachments' => [
@@ -197,7 +213,7 @@ class NotificationSlackChannelTestNotifiable
 
     public function routeNotificationForSlack()
     {
-        return 'url';
+        return 'xoxp-token';
     }
 }
 

--- a/tests/webhook/NotificationSlackChannelTest.php
+++ b/tests/webhook/NotificationSlackChannelTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Illuminate\Tests\Notifications\Webhook;
+
+use Mockery as m;
+use GuzzleHttp\Client;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Channels\SlackWebhookChannel;
+
+class NotificationSlackChannelTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Notifications\Channels\SlackWebhookChannel
+     */
+    private $slackChannel;
+
+    /**
+     * @var \Mockery\MockInterface|\GuzzleHttp\Client
+     */
+    private $guzzleHttp;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->guzzleHttp = m::mock(Client::class);
+
+        $this->slackChannel = new SlackWebhookChannel($this->guzzleHttp);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /**
+     * @dataProvider payloadDataProvider
+     * @param \Illuminate\Notifications\Notification $notification
+     * @param array $payload
+     */
+    public function testCorrectPayloadIsSentToSlack(Notification $notification, array $payload)
+    {
+        $this->guzzleHttp->shouldReceive('post')->andReturnUsing(function ($argUrl, $argPayload) use ($payload) {
+            $this->assertEquals($argUrl, 'url');
+            $this->assertEquals($argPayload, $payload);
+        });
+
+        $this->slackChannel->send(new NotificationSlackChannelTestNotifiable, $notification);
+    }
+
+    public function payloadDataProvider()
+    {
+        return [
+            'payloadWithIcon' => $this->getPayloadWithIcon(),
+            'payloadWithImageIcon' => $this->getPayloadWithImageIcon(),
+            'payloadWithoutOptionalFields' => $this->getPayloadWithoutOptionalFields(),
+            'payloadWithAttachmentFieldBuilder' => $this->getPayloadWithAttachmentFieldBuilder(),
+        ];
+    }
+
+    private function getPayloadWithIcon()
+    {
+        return [
+            new NotificationSlackChannelTestNotification,
+            [
+                'json' => [
+                    'username' => 'Ghostbot',
+                    'icon_emoji' => ':ghost:',
+                    'channel' => '#ghost-talk',
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'title_link' => 'https://laravel.com',
+                            'text' => 'Attachment Content',
+                            'fallback' => 'Attachment Fallback',
+                            'fields' => [
+                                [
+                                    'title' => 'Project',
+                                    'value' => 'Laravel',
+                                    'short' => true,
+                                ],
+                            ],
+                            'mrkdwn_in' => ['text'],
+                            'footer' => 'Laravel',
+                            'footer_icon' => 'https://laravel.com/fake.png',
+                            'author_name' => 'Author',
+                            'author_link' => 'https://laravel.com/fake_author',
+                            'author_icon' => 'https://laravel.com/fake_author.png',
+                            'ts' => 1234567890,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function getPayloadWithImageIcon()
+    {
+        return [
+            new NotificationSlackChannelTestNotificationWithImageIcon,
+            [
+                'json' => [
+                    'username' => 'Ghostbot',
+                    'icon_url' => 'http://example.com/image.png',
+                    'channel' => '#ghost-talk',
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'title_link' => 'https://laravel.com',
+                            'text' => 'Attachment Content',
+                            'fallback' => 'Attachment Fallback',
+                            'fields' => [
+                                [
+                                    'title' => 'Project',
+                                    'value' => 'Laravel',
+                                    'short' => true,
+                                ],
+                            ],
+                            'mrkdwn_in' => ['text'],
+                            'footer' => 'Laravel',
+                            'footer_icon' => 'https://laravel.com/fake.png',
+                            'ts' => 1234567890,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function getPayloadWithoutOptionalFields()
+    {
+        return [
+            new NotificationSlackChannelWithoutOptionalFieldsTestNotification,
+            [
+                'json' => [
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'title_link' => 'https://laravel.com',
+                            'text' => 'Attachment Content',
+                            'fields' => [
+                                [
+                                    'title' => 'Project',
+                                    'value' => 'Laravel',
+                                    'short' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getPayloadWithAttachmentFieldBuilder()
+    {
+        return [
+            new NotificationSlackChannelWithAttachmentFieldBuilderTestNotification,
+            [
+                'json' => [
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'text' => 'Attachment Content',
+                            'title_link' => 'https://laravel.com',
+                            'fields' => [
+                                [
+                                    'title' => 'Project',
+                                    'value' => 'Laravel',
+                                    'short' => true,
+                                ],
+                                [
+                                    'title' => 'Special powers',
+                                    'value' => 'Zonda',
+                                    'short' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}
+
+class NotificationSlackChannelTestNotifiable
+{
+    use Notifiable;
+
+    public function routeNotificationForSlack()
+    {
+        return 'url';
+    }
+}
+
+class NotificationSlackChannelTestNotification extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->from('Ghostbot', ':ghost:')
+                    ->to('#ghost-talk')
+                    ->content('Content')
+                    ->attachment(function ($attachment) {
+                        $timestamp = m::mock(Carbon::class);
+                        $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
+                        $attachment->title('Laravel', 'https://laravel.com')
+                                   ->content('Attachment Content')
+                                   ->fallback('Attachment Fallback')
+                                   ->fields([
+                                        'Project' => 'Laravel',
+                                    ])
+                                    ->footer('Laravel')
+                                    ->footerIcon('https://laravel.com/fake.png')
+                                    ->markdown(['text'])
+                                    ->author('Author', 'https://laravel.com/fake_author', 'https://laravel.com/fake_author.png')
+                                    ->timestamp($timestamp);
+                    });
+    }
+}
+
+class NotificationSlackChannelTestNotificationWithImageIcon extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->from('Ghostbot')
+                    ->image('http://example.com/image.png')
+                    ->to('#ghost-talk')
+                    ->content('Content')
+                    ->attachment(function ($attachment) {
+                        $timestamp = m::mock(Carbon::class);
+                        $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
+                        $attachment->title('Laravel', 'https://laravel.com')
+                                   ->content('Attachment Content')
+                                   ->fallback('Attachment Fallback')
+                                   ->fields([
+                                        'Project' => 'Laravel',
+                                    ])
+                                    ->footer('Laravel')
+                                    ->footerIcon('https://laravel.com/fake.png')
+                                    ->markdown(['text'])
+                                    ->timestamp($timestamp);
+                    });
+    }
+}
+
+class NotificationSlackChannelWithoutOptionalFieldsTestNotification extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->content('Content')
+                    ->attachment(function ($attachment) {
+                        $attachment->title('Laravel', 'https://laravel.com')
+                                   ->content('Attachment Content')
+                                   ->fields([
+                                        'Project' => 'Laravel',
+                                    ]);
+                    });
+    }
+}
+
+class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->content('Content')
+            ->attachment(function ($attachment) {
+                $attachment->title('Laravel', 'https://laravel.com')
+                    ->content('Attachment Content')
+                    ->field('Project', 'Laravel')
+                    ->field(function ($attachmentField) {
+                        $attachmentField
+                            ->title('Special powers')
+                            ->content('Zonda')
+                            ->long();
+                    });
+            });
+    }
+}


### PR DESCRIPTION
Slack recently modified their incoming webhook functionalities. Unfortunately, now Slack messages can only be sent to a single channel (that needs to be specified when adding a Slack app to a Slack workspace).

In the Laravel docs it is stated that SlackMessage instances have a "to" method to specify the recipient (see https://laravel.com/docs/5.8/notifications#slack-notifications). However, due to the changes made by Slack, this method is not working any longer (the message is always sent to the channel specified).

Instead of using incoming webhooks one can also utilize the Slack API, more specifically the method "chat.postMessage" (see https://api.slack.com/methods/chat.postMessage). Using this method one overcomes the limitations of the incoming webhook functionalities.

The changes implemented in this pull request are fully backwards compatible:
- If the Slack route specified for the Notifiable instance returns "https://hooks.slack.com/services/..." incoming webhooks are utilized (nothing changes)
- If the Slack route specified for the Notifiable instance instead returns "xoxp-..." (a Slack OAuth token) the API is utilized