### PR TITLE
[2.0] Update .styleci.yml

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,4 @@
 php:
   preset: laravel
-  enabled:
-    - alpha_ordered_imports
-  disabled:
-    - length_ordered_imports
 js: true
 css: true


### PR DESCRIPTION
Alpha ordered imports are now the default for the laravel preset on styleci.io.