### PR TITLE
set buildJsonPayload method as public

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -52,7 +52,7 @@ class SlackWebhookChannel
      * @param  \Illuminate\Notifications\Messages\SlackMessage  $message
      * @return array
      */
-    protected function buildJsonPayload(SlackMessage $message)
+    public function buildJsonPayload(SlackMessage $message)
     {
         $optionalFields = array_filter([
             'channel' => data_get($message, 'channel'),


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

we need to access `buildJsonPayload` so we can get a slack payload right now we are copying this method which is not good solution since we rely on this package for discord ( discord accept slack payload )

