### PR TITLE
[3.x] Bump the dependencies for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.0|^7.0",
-        "illuminate/notifications": "^6.0|^7.0"
+        "php": "^7.3",
+        "guzzlehttp/guzzle": "^7.0",
+        "illuminate/notifications": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I can't install this package because i'm working on project for laravel 8 (dev)

This is the error: 

```
Your requirements could not be resolved to an installable set of packages.

    ... (other composer's stuff)

    - arcanedev/support 8.x-dev requires laravel/framework ^8.0 -> satisfiable by laravel/framework[8.x-dev].
    - Installation request for arcanedev/support ^8.0 -> satisfiable by arcanedev/support[8.x-dev].
    - Installation request for laravel/slack-notification-channel ^2.0 -> satisfiable by laravel/slack-notification-channel[2.0.x-dev, v2.0.0, v2.0.1, v2.0.2, v2.1.0].
```

I hope this change solves the issue