### PR TITLE
Add callback id for attachments

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -86,6 +86,7 @@ class SlackWebhookChannel
                 'author_icon' => $attachment->authorIcon,
                 'author_link' => $attachment->authorLink,
                 'author_name' => $attachment->authorName,
+                'callback_id' => $attachment->callbackId,
                 'color' => $attachment->color ?: $message->color(),
                 'fallback' => $attachment->fallback,
                 'fields' => $this->fields($attachment),

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -128,7 +128,7 @@ class SlackAttachment
     public $timestamp;
 
     /**
-     * The attachment's callback id.
+     * The attachment's callback ID.
      *
      * @var int
      */
@@ -354,7 +354,7 @@ class SlackAttachment
     }
 
     /**
-     * Set the callback id.
+     * Set the callback ID.
      *
      * @param  string  $callbackId
      * @return $this

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -128,6 +128,13 @@ class SlackAttachment
     public $timestamp;
 
     /**
+     * The attachment's callback id.
+     *
+     * @var int
+     */
+    public $callbackId;
+
+    /**
      * Set the title of the attachment.
      *
      * @param  string  $title
@@ -342,6 +349,19 @@ class SlackAttachment
     public function timestamp($timestamp)
     {
         $this->timestamp = $this->availableAt($timestamp);
+
+        return $this;
+    }
+
+    /**
+     * Set the callback id.
+     *
+     * @param  string  $callbackId
+     * @return $this
+     */
+    public function callbackId($callbackId)
+    {
+        $this->callbackId = $callbackId;
 
         return $this;
     }

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -174,6 +174,7 @@ class NotificationSlackChannelTest extends TestCase
                             'title' => 'Laravel',
                             'text' => 'Attachment Content',
                             'title_link' => 'https://laravel.com',
+                            'callback_id' => 'attachment_callbackid',
                             'fields' => [
                                 [
                                     'title' => 'Project',
@@ -282,6 +283,7 @@ class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends
                 $attachment->title('Laravel', 'https://laravel.com')
                     ->content('Attachment Content')
                     ->field('Project', 'Laravel')
+                    ->callbackId('attachment_callbackid')
                     ->field(function ($attachmentField) {
                         $attachmentField
                             ->title('Special powers')


### PR DESCRIPTION
Hi,

I want to [attach interactive message buttons](https://laravel.com/docs/contributions#which-branch) to a notification which is currently not possible.

This PR adds a new field to contain the needed callback id.

