### PR TITLE
[2.x] Fix method naming

### DIFF
--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -341,7 +341,7 @@ class SlackAttachment
     }
 
     /**
-     * Set the timestamp by the number of seconds (or DateInterval) starting from now or a specific DateTime moment.
+     * Set the timestamp a DateTimeInterface, DateInterval, or the number of seconds that should be added to the current time.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $timestamp
      * @return $this

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -341,14 +341,14 @@ class SlackAttachment
     }
 
     /**
-     * Set the timestamp by passing a DateTime or a DateInterval instance, or a given number of seconds to delay.
+     * Set the timestamp by the number of seconds (or DateInterval) starting from now or a specific DateTime moment.
      *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  \DateTimeInterface|\DateInterval|int  $timestamp
      * @return $this
      */
-    public function timestamp($delay)
+    public function timestamp($timestamp)
     {
-        $this->timestamp = $this->availableAt($delay);
+        $this->timestamp = $this->availableAt($timestamp);
 
         return $this;
     }

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -341,14 +341,14 @@ class SlackAttachment
     }
 
     /**
-     * Set the timestamp.
+     * Set the timestamp by passing a DateTime or a DateInterval instance, or a given number of seconds to delay.
      *
-     * @param  \DateTimeInterface|\DateInterval|int  $timestamp
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @return $this
      */
-    public function timestamp($timestamp)
+    public function timestamp($delay)
     {
-        $this->timestamp = $this->availableAt($timestamp);
+        $this->timestamp = $this->availableAt($delay);
 
         return $this;
     }


### PR DESCRIPTION
This PR clarifies the use of the timestamp method which now incorrectly says it'll set the actual timestamp. In fact, either a `DateTime`, `DateInterval` or a given number of delayed seconds until the attachment can be set should be passed.