### PR TITLE
Fix PHPDoc type annotations

### DIFF
--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -235,7 +235,7 @@ class SlackMessage
     /**
      * Unfurl links to rich display.
      *
-     * @param  string  $unfurl
+     * @param  bool  $unfurl
      * @return $this
      */
     public function unfurlLinks($unfurl)
@@ -248,7 +248,7 @@ class SlackMessage
     /**
      * Unfurl media to rich display.
      *
-     * @param  string  $unfurl
+     * @param  bool  $unfurl
      * @return $this
      */
     public function unfurlMedia($unfurl)

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -235,12 +235,12 @@ class SlackMessage
     /**
      * Unfurl links to rich display.
      *
-     * @param  bool  $unfurl
+     * @param  bool  $unfurlLinks
      * @return $this
      */
-    public function unfurlLinks($unfurl)
+    public function unfurlLinks($unfurlLinks)
     {
-        $this->unfurlLinks = $unfurl;
+        $this->unfurlLinks = $unfurlLinks;
 
         return $this;
     }
@@ -248,12 +248,12 @@ class SlackMessage
     /**
      * Unfurl media to rich display.
      *
-     * @param  bool  $unfurl
+     * @param  bool  $unfurlMedia
      * @return $this
      */
-    public function unfurlMedia($unfurl)
+    public function unfurlMedia($unfurlMedia)
     {
-        $this->unfurlMedia = $unfurl;
+        $this->unfurlMedia = $unfurlMedia;
 
         return $this;
     }


### PR DESCRIPTION
Both `SlackMessage::unfurlLinks` and `SlackMessage::unfurlMedia` have boolean types, but PHPDoc for their setters use `string` type.


Additionally, I've changed arg names to keep them in sync with property names (the main problem was invalid arg name: `public function unfurlMedia($unfurl)`).


PS: a note about arguments renaming:
![image](https://user-images.githubusercontent.com/5278175/107114146-cd03b780-6874-11eb-8b16-fb59d6d3e644.png)
