### PR TITLE
Adding Discord Slack style notification support

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -41,6 +41,10 @@ class SlackWebhookChannel
             return;
         }
 
+        if (in_array(parse_url($url)['host'], ['discord.com', 'ptb.discord.com', 'canary.discord.com']) && !(substr_compare($url, '/slack', -6) === 0)) {
+            $url .= '/slack';
+        }
+
         return $this->http->post($url, $this->buildJsonPayload(
             $notification->toSlack($notifiable)
         ));

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -41,7 +41,7 @@ class SlackWebhookChannel
             return;
         }
 
-        if (in_array(parse_url($url)['host'], ['discord.com', 'ptb.discord.com', 'canary.discord.com']) && !(substr_compare($url, '/slack', -6) === 0)) {
+        if (in_array(parse_url($url)['host'], ['discord.com', 'ptb.discord.com', 'canary.discord.com']) && ! (substr_compare($url, '/slack', -6) === 0)) {
             $url .= '/slack';
         }
 


### PR DESCRIPTION
The following PR allows support for Discord "Slack" notifications out of the box. Discord allows sending webhooks in the style of Slack (referenced here in their [developer docs](https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook)), with a slight modification to the webhook URL (appending `/slack`).

In this PR, the change checks to see if the `routeNotificationForSlack` return a url that includes a Discord host (a list of hosts can be found here [in one of their support articles](https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients); which is dependent on the client version the developer creates the webhook from). From there, it also checks to make sure that the developer hasn't already appended the `/slack` url "flag". If both cases are true, `/slack` is appended to the notification url automatically allowing developers to use this repo to support sending notifications to Discord on top of slack.

While most webhook properties are supported, there are a few to note that aren't supported (as listed on the developer docs page listed above)
- channel
- icon_emoji
- mrkdwn
- mrkdwn_in 


I do understand this is slightly out of the scope of "slack" and if it's not accepted, no worries. 🙂