### PR TITLE
Add actions method to SlackAttachment class

### DIFF
--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -298,6 +298,19 @@ class SlackAttachment
     }
 
     /**
+     * Set the actions of the attachment.
+     *
+     * @param  array  $actions
+     * @return $this
+     */
+    public function actions(array $actions)
+    {
+        $this->actions = $actions;
+
+        return $this;
+    }
+
+    /**
      * Set the author of the attachment.
      *
      * @param  string  $name


### PR DESCRIPTION
Add the actions method to the SlackAttachment class. 
This method allows for the addition of custom actions to the Slack attachment. 
