### PR TITLE
Add support for conditional Slack messages

### DIFF
--- a/src/Slack/SlackMessage.php
+++ b/src/Slack/SlackMessage.php
@@ -12,10 +12,13 @@ use Illuminate\Notifications\Slack\BlockKit\Blocks\ImageBlock;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
 use Illuminate\Notifications\Slack\Contracts\BlockContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 use LogicException;
 
 class SlackMessage implements Arrayable
 {
+    use Conditionable;
+
     /**
      * The channel to send the message on.
      */


### PR DESCRIPTION
This pull request will add the `Conditionable` trait to the `SlackMessage` class. By adding this trait the methods `when` and `unless` can be used to create a Slack notification based on conditions. The same trait is used in the `MailMessage` class. This will allow you to create, for example, Slack and mail notifications/messages based on the same conditions.