### PR TITLE
feat: Handle retry-after for slack notification channel

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -51,7 +51,7 @@ class SlackWebhookChannel
             } else {
                 throw $e;
             }
-        };
+        }
     }
 
     /**

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -47,7 +47,7 @@ class SlackWebhookChannel
             ));
         } catch (ClientException $e) {
             if ($e->getCode() === 429 && $notification instanceof ShouldQueue) {
-                $notification->release($e->getResponse()->getHeader('Retry-After')[0]);
+                $notification->release($e->getResponse()->getHeaderLine('Retry-After'));
             } else {
                 throw $e;
             }

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -211,6 +211,7 @@ class NotificationSlackChannelTest extends TestCase
 class NotificationSlackChannelTestNotification extends Notification implements ShouldQueue
 {
     public ?int $release = null;
+
     public function toSlack($notifiable)
     {
         return (new SlackMessage)


### PR DESCRIPTION
Sometimes webhook rate limits. I think it should be handled in a better way, [as per slack docs](https://api.slack.com/docs/rate-limits#headers), by releasing job back onto the queue.