### PR TITLE
Support disabling slack route dynamically when using `SlackWebhookChannel`

### DIFF
--- a/src/SlackNotificationRouterChannel.php
+++ b/src/SlackNotificationRouterChannel.php
@@ -38,6 +38,8 @@ class SlackNotificationRouterChannel
     {
         $route = $notifiable->routeNotificationFor('slack', $notification);
 
+        if ($route === false) return null;
+
         return $this->determineChannel($route)->send($notifiable, $notification);
     }
 

--- a/src/SlackNotificationRouterChannel.php
+++ b/src/SlackNotificationRouterChannel.php
@@ -38,7 +38,9 @@ class SlackNotificationRouterChannel
     {
         $route = $notifiable->routeNotificationFor('slack', $notification);
 
-        if ($route === false) return null;
+        if ($route === false) {
+            return;
+        }
 
         return $this->determineChannel($route)->send($notifiable, $notification);
     }

--- a/tests/SlackNotificationRouterChannelTest.php
+++ b/tests/SlackNotificationRouterChannelTest.php
@@ -61,6 +61,22 @@ class SlackNotificationRouterChannelTest extends TestCase
 
         $channel->send(new SlackChannelTestNotifiable('#general'), new SlackChannelTestNotification());
     }
+
+    /** @test */
+    public function it_stops_sending_when_the_notifiable_route_is_false(): void
+    {
+        $app = new Container();
+        $app->bind(SlackWebhookChannel::class, fn () => new FakeSlackChannel(function () {
+            $this->fail('The Slack Webhook Channel should not have been called.');
+        }));
+        $app->bind(SlackWebApiChannel::class, fn () => new FakeSlackChannel(function () {
+            $this->fail('The Slack WebAPI Channel should not have been called.');
+        }));
+
+        $channel = new SlackNotificationRouterChannel($app);
+
+        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(false), new SlackChannelTestNotification()));
+    }
 }
 
 class FakeSlackChannel


### PR DESCRIPTION
As described in [this issue](https://github.com/laravel/slack-notification-channel/issues/85) there is a problem when using slack webhook handler and returning `null` dynamically in `routeNotificationForSlack()` i. e. if a slack webhook url can be configured on a user-level.

When returning `null` the application [assumes `SlackWebApiChannel` should be used](https://github.com/laravel/slack-notification-channel/issues/85#issuecomment-1841869751) instead of `SlackWebhookChannel` which then leads to an error:

```
Illuminate\Notifications\Channels\SlackWebhookChannel::buildJsonPayload(): Argument #1 ($message) must be of type Illuminate\Notifications\Messages\SlackMessage, Illuminate\Notifications\Slack\SlackMessage given, called in vendor/laravel/slack-notification-channel/src/Channels/SlackWebhookChannel.php on line 43.
```

Returning a URL like [https://hooks.slack.com/](https://github.com/laravel/slack-notification-channel/issues/85#issuecomment-1846194322) would work, but would still send a post request to the given URL.

This PR allows returning `false` in `routeNotificationForSlack()` and would then stop the send process. 