### PR TITLE
Replace Guzzle with Http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "guzzlehttp/guzzle": "^7.0",
         "illuminate/http": "^9.0|^10.0|^11.0",
         "illuminate/notifications": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
+        "guzzlehttp/guzzle": "^7.0",
         "illuminate/http": "^9.0|^10.0|^11.0",
         "illuminate/notifications": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0"

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Notifications\Channels;
 
 use GuzzleHttp\Client as HttpClient;
+use Illuminate\Http\Client\Factory;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
 use Illuminate\Notifications\Messages\SlackMessage;
@@ -13,7 +14,7 @@ class SlackWebhookChannel
     /**
      * The HTTP client instance.
      *
-     * @var \GuzzleHttp\Client
+     * @var \Illuminate\Http\Client\Factory
      */
     protected $http;
 
@@ -22,7 +23,7 @@ class SlackWebhookChannel
      *
      * @return void
      */
-    public function __construct(HttpClient $http)
+    public function __construct(Factory $http)
     {
         $this->http = $http;
     }
@@ -31,12 +32,12 @@ class SlackWebhookChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @return \Psr\Http\Message\ResponseInterface|null
+     * @return \Illuminate\Http\Client\Response|null
      */
     public function send($notifiable, Notification $notification)
     {
         if (! $url = $notifiable->routeNotificationFor('slack', $notification)) {
-            return;
+            return null;
         }
 
         return $this->http->post($url, $this->buildJsonPayload(

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Notifications\Channels;
 
-use GuzzleHttp\Client as HttpClient;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackAttachmentField;


### PR DESCRIPTION
# What does this PR do?

- Replaced Guzzle with Laravel's `Http` class in `SlackWebhookChannel`

# Why?

Short version: testability.

Longer version:

[This issue](https://github.com/laravel/slack-notification-channel/issues/85) was the trigger for me: when running tests that use an old webhook-style integration, you will be presented with `Error using Illuminate\Notifications\Slack\SlackMessage buildJsonPayload` errors.

In my particular case, I do not have the ability to overrride `routeNotificationFor` because I am not triggering my notification from a model, but am doing it as so:

```php
            Notification::route('slack', config('services.slack.url'))
                ->notify(new MyAwesomeNotification($foo, $bar, $baz));

```

I tried overriding the config in the tests to point to `https://hook.slack.com` but then we are presented with a 404 page, without an easy ability to mock this URL.

Hence, this is why using the native Http client from Laravel is preferred: we can just mock this request from our tests and be done, and all is well again in the world.

# Tests

Tests have been updated to reflect this change.