### PR TITLE
feat: support threaded replies for SlackMessage

### DIFF
--- a/src/Slack/SlackMessage.php
+++ b/src/Slack/SlackMessage.php
@@ -72,6 +72,16 @@ class SlackMessage implements Arrayable
     protected ?string $username = null;
 
     /**
+     * Unique, per-channel, timestamp for each message. If provided, send message as a thread reply to this message.
+     */
+    protected ?string $threadTs = null;
+
+    /**
+     * If sending message as reply to thread, whether to 'broadcast' a reference to the thread reply to the parent conversation.
+     */
+    protected ?bool $replyBroadcast = null;
+
+    /**
      * Set the Slack channel the message should be sent to.
      */
     public function to(string $channel): self
@@ -239,6 +249,26 @@ class SlackMessage implements Arrayable
     }
 
     /**
+     * Set the thread timestamp (message ID) to send as reply to thread.
+     */
+    public function threadTimestamp(?string $threadTimestamp): self
+    {
+        $this->threadTs = $threadTimestamp;
+
+        return $this;
+    }
+
+    /**
+     * Only applicable if threadTimestamp is set. 'Broadcasts' a reference to the threaded reply to the parent conversation.
+     */
+    public function replyBroadcast(?bool $replyBroadcast): self
+    {
+        $this->replyBroadcast = $replyBroadcast;
+
+        return $this;
+    }
+
+    /**
      * Get the instance as an array.
      */
     public function toArray(): array
@@ -258,6 +288,8 @@ class SlackMessage implements Arrayable
             'icon_url' => $this->image,
             'metadata' => $this->metaData?->toArray(),
             'mrkdwn' => $this->mrkdwn,
+            'thread_ts' => $this->threadTs,
+            'reply_broadcast' => $this->replyBroadcast,
             'unfurl_links' => $this->unfurlLinks,
             'unfurl_media' => $this->unfurlMedia,
             'username' => $this->username,

--- a/src/Slack/SlackMessage.php
+++ b/src/Slack/SlackMessage.php
@@ -79,7 +79,7 @@ class SlackMessage implements Arrayable
     /**
      * If sending message as reply to thread, whether to 'broadcast' a reference to the thread reply to the parent conversation.
      */
-    protected ?bool $replyBroadcast = null;
+    protected ?bool $broadcastReply = null;
 
     /**
      * Set the Slack channel the message should be sent to.
@@ -259,11 +259,11 @@ class SlackMessage implements Arrayable
     }
 
     /**
-     * Only applicable if threadTimestamp is set. 'Broadcasts' a reference to the threaded reply to the parent conversation.
+     * Only applicable if threadTimestamp is set. Broadcasts a reference to the threaded reply to the parent conversation.
      */
-    public function replyBroadcast(?bool $replyBroadcast): self
+    public function broadcastReply(?bool $broadcastReply = true): self
     {
-        $this->replyBroadcast = $replyBroadcast;
+        $this->broadcastReply = $broadcastReply;
 
         return $this;
     }
@@ -289,7 +289,7 @@ class SlackMessage implements Arrayable
             'metadata' => $this->metaData?->toArray(),
             'mrkdwn' => $this->mrkdwn,
             'thread_ts' => $this->threadTs,
-            'reply_broadcast' => $this->replyBroadcast,
+            'reply_broadcast' => $this->broadcastReply,
             'unfurl_links' => $this->unfurlLinks,
             'unfurl_media' => $this->unfurlMedia,
             'username' => $this->username,

--- a/tests/Slack/Feature/SlackMessageTest.php
+++ b/tests/Slack/Feature/SlackMessageTest.php
@@ -205,7 +205,7 @@ class SlackMessageTest extends TestCase
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
-            $message->replyBroadcast(true);
+            $message->broadcastReply(true);
         })->assertNotificationSent([
             'channel' => '#ghost-talk',
             'text' => 'See https://api.slack.com/methods/chat.postMessage for more information.',

--- a/tests/Slack/Feature/SlackMessageTest.php
+++ b/tests/Slack/Feature/SlackMessageTest.php
@@ -188,6 +188,32 @@ class SlackMessageTest extends TestCase
     }
 
     /** @test */
+    public function it_can_reply_as_thread(): void
+    {
+        $this->sendNotification(function (SlackMessage $message) {
+            $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
+            $message->threadTimestamp('123456.7890');
+        })->assertNotificationSent([
+            'channel' => '#ghost-talk',
+            'text' => 'See https://api.slack.com/methods/chat.postMessage for more information.',
+            'thread_ts' => '123456.7890',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_send_threaded_reply_as_broadcast_reference(): void
+    {
+        $this->sendNotification(function (SlackMessage $message) {
+            $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
+            $message->replyBroadcast(true);
+        })->assertNotificationSent([
+            'channel' => '#ghost-talk',
+            'text' => 'See https://api.slack.com/methods/chat.postMessage for more information.',
+            'reply_broadcast' => true,
+        ]);
+    }
+
+    /** @test */
     public function it_can_set_the_bot_user_name(): void
     {
         $this->sendNotification(function (SlackMessage $message) {


### PR DESCRIPTION
Allows setting of `thread_ts` and `reply_broadcast` in SlackMessage. Is used for replying as a threaded reply to a parent message. `reply_broadcast` is used in conjunction with `thread_ts`, whether or not to show a reference to the threaded reply in the container user/channel.