### PR TITLE
fix: do not notify when route is empty

### DIFF
--- a/src/SlackNotificationRouterChannel.php
+++ b/src/SlackNotificationRouterChannel.php
@@ -38,7 +38,7 @@ class SlackNotificationRouterChannel
     {
         $route = $notifiable->routeNotificationFor('slack', $notification);
 
-        if ($route === false) {
+        if (! $route) {
             return;
         }
 

--- a/tests/SlackNotificationRouterChannelTest.php
+++ b/tests/SlackNotificationRouterChannelTest.php
@@ -76,6 +76,9 @@ class SlackNotificationRouterChannelTest extends TestCase
         $channel = new SlackNotificationRouterChannel($app);
 
         $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(false), new SlackChannelTestNotification()));
+        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(null), new SlackChannelTestNotification()));
+        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(''), new SlackChannelTestNotification()));
+        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable([]), new SlackChannelTestNotification()));
     }
 }
 


### PR DESCRIPTION
Hello Laravel team 😃 
We moved `slack-notification-channel` from `v2` to `v3`, but not yet applied what needed to use `SlackWebApiChannel`, so for now we would like to use still `SlackWebhookChannel` for a while.

We have an issue in production :
```
TypeError
Illuminate\Notifications\Slack\SlackChannel::buildJsonPayload(): Argument #1 ($message) must be of type Illuminate\Notifications\Slack\SlackMessage, App\Notifications\Messages\SlackMessage given, called in /var/www/app.onepilot.fr/releases/20240816150940/vendor/laravel/slack-notification-channel/src/Slack/SlackChannel.php on line 41
```

I can see that it was partially fixed here : https://github.com/laravel/slack-notification-channel/pull/87
But it fixed only for `false` values.

And in some cases we would like for example to specify many channels in laravel Notification's `via()` method, like for example 👇 

<img width="402" alt="Capture d’écran 2024-08-17 à 16 01 35" src="https://github.com/user-attachments/assets/8ed8433b-69f2-4686-8630-0879c772b569">

And let's say that sometimes we want only to notify via email like that 👇 
<img width="442" alt="Capture d’écran 2024-08-17 à 16 03 54" src="https://github.com/user-attachments/assets/45e6c7b8-6d2c-40fc-9d63-9016c1bb88f5">

The slack notification will fail here because we don't specify the route and we try notifying anyway. For example when you have in your logic a notifiable that in `routeNotificationForSlack()` (or in `routeNotificationFor()` because note that `AnonymousNotifiable` doesn't have routeNotificationForSlack method) can return `null`, like in `AnonymousNotifiable` for example 👇 

<img width="392" alt="Capture d’écran 2024-08-17 à 16 07 16" src="https://github.com/user-attachments/assets/3aed959c-2baa-4b59-a444-68b18ae7be89">

<img width="862" alt="Capture d’écran 2024-08-17 à 19 16 47" src="https://github.com/user-attachments/assets/7ae84b66-0234-4f82-90aa-cec2a38aa298">


And `null` is not striclty equal to `false` in `SlackNotificationRouterChannel`'s `send` method, so the script goes on and enter `SlackWebApiChannel`, while we did not implement it yet (staying with v2 webhook way for now) and in addition we would like here only to notify by email, not slack.