### PR TITLE
Revert "fix: do not notify when route is empty"

### DIFF
--- a/src/SlackNotificationRouterChannel.php
+++ b/src/SlackNotificationRouterChannel.php
@@ -38,7 +38,7 @@ class SlackNotificationRouterChannel
     {
         $route = $notifiable->routeNotificationFor('slack', $notification);
 
-        if (! $route) {
+        if ($route === false) {
             return;
         }
 

--- a/tests/SlackNotificationRouterChannelTest.php
+++ b/tests/SlackNotificationRouterChannelTest.php
@@ -76,9 +76,6 @@ class SlackNotificationRouterChannelTest extends TestCase
         $channel = new SlackNotificationRouterChannel($app);
 
         $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(false), new SlackChannelTestNotification()));
-        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(null), new SlackChannelTestNotification()));
-        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable(''), new SlackChannelTestNotification()));
-        $this->assertEquals(null, $channel->send(new SlackChannelTestNotifiable([]), new SlackChannelTestNotification()));
     }
 }
 


### PR DESCRIPTION
Reverts laravel/slack-notification-channel#96