### PR TITLE
[3.x] Add the ability to get the Block Kit Builder url from a SlackMessage

### DIFF
--- a/src/Slack/SlackMessage.php
+++ b/src/Slack/SlackMessage.php
@@ -321,6 +321,16 @@ class SlackMessage implements Arrayable
     }
 
     /**
+     * Get the Block Kit URL for the message.
+     *
+     * @return string
+     */
+    public function toBlockKitBuilderUrl(): string
+    {
+        return 'https://app.slack.com/block-kit-builder#'.rawurlencode(json_encode(Arr::except($this->toArray(), ['username', 'text', 'channel']), true));
+    }
+
+    /**
      * Dump the payload as a URL to the Slack Block Kit Builder.
      *
      * @return void
@@ -332,10 +342,5 @@ class SlackMessage implements Arrayable
         }
 
         dd($this->toBlockKitBuilderUrl());
-    }
-
-    public function toBlockKitBuilderUrl(): string
-    {
-        return 'https://app.slack.com/block-kit-builder#'.rawurlencode(json_encode(Arr::except($this->toArray(), ['username', 'text', 'channel']), true));
     }
 }

--- a/src/Slack/SlackMessage.php
+++ b/src/Slack/SlackMessage.php
@@ -331,6 +331,11 @@ class SlackMessage implements Arrayable
             dd($this->toArray());
         }
 
-        dd('https://app.slack.com/block-kit-builder#'.rawurlencode(json_encode(Arr::except($this->toArray(), ['username', 'text', 'channel']), true)));
+        dd($this->toBlockKitBuilderUrl());
+    }
+
+    public function toBlockKitBuilderUrl(): string
+    {
+        return 'https://app.slack.com/block-kit-builder#'.rawurlencode(json_encode(Arr::except($this->toArray(), ['username', 'text', 'channel']), true));
     }
 }

--- a/tests/Slack/Feature/SlackMessageTest.php
+++ b/tests/Slack/Feature/SlackMessageTest.php
@@ -573,4 +573,30 @@ class SlackMessageTest extends TestCase
             ],
         ]);
     }
+
+    /** @test */
+    public function it_can_return_an_block_kit_builder_url() {
+        $message = (new SlackChannelTestNotification(function (SlackMessage $message) {
+            $message
+                ->username('larabot')
+                ->to('#ghost-talk')
+                ->headerBlock('Budget Performance')
+                ->sectionBlock(function (SectionBlock $sectionBlock) {
+                    $sectionBlock->text('A message *with some bold text* and _some italicized text_.')->markdown();
+                });
+        }))->toSlack(
+            new SlackChannelTestNotifiable(new SlackRoute('#ghost-talk', 'fake-token'))
+        );
+
+        $returnedUrl = $message->toBlockKitBuilderUrl();
+        $expectedUrl = 'https://app.slack.com/block-kit-builder#'
+            .rawurlencode('{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Budget Performance"}},{"type":"section","text":{"type":"mrkdwn","text":"A message *with some bold text* and _some italicized text_."}}]}');
+
+        $this->assertStringNotContainsStringIgnoringCase('username', $returnedUrl);
+        $this->assertStringNotContainsStringIgnoringCase('larabot', $returnedUrl);
+        $this->assertStringNotContainsStringIgnoringCase('channel', $returnedUrl);
+        $this->assertStringNotContainsStringIgnoringCase('#ghost-talk', $returnedUrl);
+
+        $this->assertEquals($expectedUrl, $returnedUrl);
+    }
 }

--- a/tests/Slack/Feature/SlackMessageTest.php
+++ b/tests/Slack/Feature/SlackMessageTest.php
@@ -575,7 +575,8 @@ class SlackMessageTest extends TestCase
     }
 
     /** @test */
-    public function it_can_return_an_block_kit_builder_url() {
+    public function it_can_return_an_block_kit_builder_url()
+    {
         $message = (new SlackChannelTestNotification(function (SlackMessage $message) {
             $message
                 ->username('larabot')


### PR DESCRIPTION
This PR adds the ability to return the Block Kit Builder URL from the `Illuminate\Notifications\Slack\SlackMessage` class without needing to dump. 