### PR TITLE
PHP 8.4 - Deprecation Warnings

### DIFF
--- a/src/Slack/BlockKit/Blocks/ContextBlock.php
+++ b/src/Slack/BlockKit/Blocks/ContextBlock.php
@@ -42,7 +42,7 @@ class ContextBlock implements BlockContract
     /**
      * Add an image element to the block.
      */
-    public function image(string $imageUrl, string $altText = null): ImageElement
+    public function image(string $imageUrl, ?string $altText = null): ImageElement
     {
         return tap(new ImageElement($imageUrl, $altText), function (ImageElement $element) {
             $this->elements[] = $element;

--- a/src/Slack/BlockKit/Blocks/HeaderBlock.php
+++ b/src/Slack/BlockKit/Blocks/HeaderBlock.php
@@ -28,7 +28,7 @@ class HeaderBlock implements BlockContract
     /**
      * Create a new header block instance.
      */
-    public function __construct(string $text, Closure $callback = null)
+    public function __construct(string $text, ?Closure $callback = null)
     {
         $this->text = $object = new PlainTextOnlyTextObject($text, 150);
 

--- a/src/Slack/BlockKit/Blocks/ImageBlock.php
+++ b/src/Slack/BlockKit/Blocks/ImageBlock.php
@@ -42,7 +42,7 @@ class ImageBlock implements BlockContract
     /**
      * Create a new image block instance.
      */
-    public function __construct(string $url, string $altText = null)
+    public function __construct(string $url, ?string $altText = null)
     {
         if (strlen($url) > 3000) {
             throw new InvalidArgumentException('Maximum length for the url field is 3000 characters.');

--- a/src/Slack/BlockKit/Elements/ButtonElement.php
+++ b/src/Slack/BlockKit/Elements/ButtonElement.php
@@ -79,7 +79,7 @@ class ButtonElement implements ElementContract
     /**
      * Create a new button element instance.
      */
-    public function __construct(string $text, Closure $callback = null)
+    public function __construct(string $text, ?Closure $callback = null)
     {
         $this->text = new PlainTextOnlyTextObject($text, 75);
 
@@ -155,7 +155,7 @@ class ButtonElement implements ElementContract
     /**
      * Set the confirm object for the button.
      */
-    public function confirm(string $text, Closure $callback = null): ConfirmObject
+    public function confirm(string $text, ?Closure $callback = null): ConfirmObject
     {
         $this->confirm = $confirm = new ConfirmObject($text);
 

--- a/src/Slack/BlockKit/Elements/ImageElement.php
+++ b/src/Slack/BlockKit/Elements/ImageElement.php
@@ -20,7 +20,7 @@ class ImageElement implements ElementContract
     /**
      * Create a new image element instance.
      */
-    public function __construct(string $url, string $altText = null)
+    public function __construct(string $url, ?string $altText = null)
     {
         $this->url = $url;
         $this->altText = $altText;

--- a/src/Slack/SlackMessage.php
+++ b/src/Slack/SlackMessage.php
@@ -139,7 +139,7 @@ class SlackMessage implements Arrayable
     /**
      * Add a new Header block to the message.
      */
-    public function headerBlock(string $text, Closure $callback = null): self
+    public function headerBlock(string $text, ?Closure $callback = null): self
     {
         $this->blocks[] = new HeaderBlock($text, $callback);
 
@@ -149,7 +149,7 @@ class SlackMessage implements Arrayable
     /**
      * Add a new Image block to the message.
      */
-    public function imageBlock(string $url, Closure|string $altText = null, Closure $callback = null): self
+    public function imageBlock(string $url, Closure|string|null $altText = null, ?Closure $callback = null): self
     {
         if ($altText instanceof Closure) {
             $callback = $altText;

--- a/src/Slack/SlackRoute.php
+++ b/src/Slack/SlackRoute.php
@@ -21,7 +21,7 @@ class SlackRoute
     /**
      * Create a new Slack route instance.
      */
-    public function __construct(string $channel = null, string $token = null)
+    public function __construct(?string $channel = null, ?string $token = null)
     {
         $this->channel = $channel;
         $this->token = $token;
@@ -30,7 +30,7 @@ class SlackRoute
     /**
      * Fluently create a new Slack route instance.
      */
-    public static function make(string $channel = null, string $token = null): self
+    public static function make(?string $channel = null, ?string $token = null): self
     {
         return new self($channel, $token);
     }

--- a/tests/Slack/SlackChannelTestNotification.php
+++ b/tests/Slack/SlackChannelTestNotification.php
@@ -10,7 +10,7 @@ class SlackChannelTestNotification extends Notification
 {
     private Closure $callback;
 
-    public function __construct(Closure $callback = null)
+    public function __construct(?Closure $callback = null)
     {
         $this->callback = $callback ?? function () {
             //


### PR DESCRIPTION
Make types explicitly nullable to fix `E_DEPRECATED` warnings in PHP 8.4

```
Illuminate\Notifications\Slack\BlockKit\Blocks\HeaderBlock::__construct(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead
```