### PR TITLE
Support sending the new BlockKit message via SlackWebhookChannel

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -5,8 +5,9 @@ namespace Illuminate\Notifications\Channels;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
-use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Messages\SlackMessage as LegacySlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Slack\SlackMessage;
 
 class SlackWebhookChannel
 {
@@ -47,10 +48,15 @@ class SlackWebhookChannel
     /**
      * Build up a JSON payload for the Slack webhook.
      *
+     * @param  LegacySlackMessage|SlackMessage  $message
      * @return array
      */
-    public function buildJsonPayload(SlackMessage $message)
+    public function buildJsonPayload(LegacySlackMessage|SlackMessage $message)
     {
+        if ($message instanceof SlackMessage) {
+            return ['json' => $message->toArray()];
+        }
+
         $optionalFields = array_filter([
             'channel' => data_get($message, 'channel'),
             'icon_emoji' => data_get($message, 'icon'),
@@ -74,7 +80,7 @@ class SlackWebhookChannel
      *
      * @return array
      */
-    protected function attachments(SlackMessage $message)
+    protected function attachments(LegacySlackMessage $message)
     {
         return collect($message->attachments)->map(function ($attachment) use ($message) {
             return array_filter([

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -48,10 +48,10 @@ class SlackWebhookChannel
     /**
      * Build up a JSON payload for the Slack webhook.
      *
-     * @param  LegacySlackMessage|SlackMessage  $message
+     * @param  SlackMessage|LegacySlackMessage  $message
      * @return array
      */
-    public function buildJsonPayload(LegacySlackMessage|SlackMessage $message)
+    public function buildJsonPayload(SlackMessage|LegacySlackMessage $message)
     {
         if ($message instanceof SlackMessage) {
             return ['json' => $message->toArray()];

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -4,6 +4,12 @@ namespace Illuminate\Notifications\Messages;
 
 use Closure;
 
+/**
+ * Legacy Slack message with attachments.
+ *
+ * @link https://api.slack.com/legacy/outmoded-messaging
+ * @see  \Illuminate\Notifications\Slack\SlackMessage build messages with layout blocks.
+ */
 class SlackMessage
 {
     /**

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -8,7 +8,7 @@ use Closure;
  * Legacy Slack message with attachments.
  *
  * @link https://api.slack.com/legacy/outmoded-messaging
- * @see  \Illuminate\Notifications\Slack\SlackMessage build messages with layout blocks.
+ * @see  \Illuminate\Notifications\Slack\SlackMessage
  */
 class SlackMessage
 {


### PR DESCRIPTION
## Background

In early 2019, Slack introduced a new way of composing messages, by [using blocks to create rich and interactive layouts](https://api.slack.com/messaging/interactivity). Slack apps designed and built before then may have used features such as [attachments](https://api.slack.com/reference/messaging/attachments) which are now considered outmoded.

These older features will continue to work, but apps using them will miss out on the [new layout](https://api.slack.com/surfaces/messages#complex_layouts) and [interactivity features](https://api.slack.com/messaging/interactivity) blocks provide.

## User Story

My team uses Slack for internal notifications, which are typically sent by bots. For a specific Slack channel, generating an incoming webhook is much simpler and more user-friendly than configuring an app and authorizing an OAuth token. Slack now officially supports sending messages with layout blocks via webhooks, making it even easier to deliver rich, interactive messages without the overhead of app management.

## Description

This PR adds support for sending Block Kit messages via the `SlackWebhookChannel`.

To avoid ambiguity, the original `Illuminate\Notifications\Messages\SlackMessage` class has been aliased as `LegacySlackMessage` within the `SlackWebhookChannel` class. This approach was chosen to maximize backward compatibility, without directly modifying the original namespace or class name.
