### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,11 @@ jobs:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, 12, 13]
         include:
+          - php: 8.2
+            laravel: 9
           - php: 8.1
             laravel: 9
-          - php: 8.2
+          - php: '8.0'
             laravel: 9
         exclude:
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,28 +17,36 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10, 11, 12]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10, 11, 12, 13]
         include:
-          - php: 8.2
-            laravel: 9
           - php: 8.1
             laravel: 9
-          - php: '8.0'
+          - php: 8.2
             laravel: 9
         exclude:
           - php: 8.1
             laravel: 11
           - php: 8.1
             laravel: 12
+          - php: 8.1
+            laravel: 13
+          - php: 8.2
+            laravel: 13
           - php: 8.4
             laravel: 10
+          - php: 8.5
+            laravel: 10
+          - php: 8.5
+            laravel: 11
+          - php: 8.5
+            laravel: 12
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0"
+        "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.0|^10.4|^11.5"
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "phpstan/phpstan": "^1.10|^2.0",
+        "phpunit/phpunit": "^9.0|^10.4|^11.5|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -10,6 +10,7 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Carbon;
 use Illuminate\Tests\Notifications\Slack\SlackChannelTestNotifiable;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class NotificationSlackChannelTest extends TestCase
@@ -19,9 +20,8 @@ class NotificationSlackChannelTest extends TestCase
         m::close();
     }
 
-    /**
-     * @dataProvider payloadDataProvider
-     */
+    /** @dataProvider payloadDataProvider */
+    #[DataProvider('payloadDataProvider')]
     public function testCorrectPayloadIsSentToSlack(Notification $notification, array $payload)
     {
         $guzzleHttp = m::mock(Client::class);

--- a/tests/Slack/Feature/SlackChannelTest.php
+++ b/tests/Slack/Feature/SlackChannelTest.php
@@ -14,8 +14,7 @@ use LogicException;
 
 class SlackChannelTest extends TestCase
 {
-    /** @test */
-    public function the_route_notification_for_slack_method_describes_the_channel_using_a_string(): void
+    public function test_the_route_notification_for_slack_method_describes_the_channel_using_a_string(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'config-set-token');
 
@@ -39,8 +38,7 @@ class SlackChannelTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_route_notification_for_slack_method_describes_the_channel_using_a_slack_route_instance(): void
+    public function test_the_route_notification_for_slack_method_describes_the_channel_using_a_slack_route_instance(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'config-set-token');
 
@@ -64,8 +62,7 @@ class SlackChannelTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_route_notification_for_slack_method_describes_the_channel_and_token_using_a_slack_route_instance(): void
+    public function test_the_route_notification_for_slack_method_describes_the_channel_and_token_using_a_slack_route_instance(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'config-set-token');
 
@@ -89,8 +86,7 @@ class SlackChannelTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_route_notification_for_slack_method_only_describes_the_token_using_a_slack_route_instance(): void
+    public function test_the_route_notification_for_slack_method_only_describes_the_token_using_a_slack_route_instance(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'ignored-token');
 
@@ -114,8 +110,7 @@ class SlackChannelTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_route_notification_for_slack_method_does_not_describe_anything(): void
+    public function test_the_route_notification_for_slack_method_does_not_describe_anything(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'config-set-token');
         Config::set('services.slack.notifications.channel', 'config-set-channel');
@@ -140,8 +135,7 @@ class SlackChannelTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_prefers_the_notification_defined_channel_over_the_config_defined_channel(): void
+    public function test_it_prefers_the_notification_defined_channel_over_the_config_defined_channel(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'config-set-token');
         Config::set('services.slack.notifications.channel', 'config-set-channel');
@@ -166,8 +160,7 @@ class SlackChannelTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_the_route_notification_for_slack_method_does_not_provide_a_channel_and_the_notification_and_config_do_not_either(): void
+    public function test_it_throws_an_exception_when_the_route_notification_for_slack_method_does_not_provide_a_channel_and_the_notification_and_config_do_not_either(): void
     {
         Config::set('services.slack.notifications.bot_user_oauth_token', 'config-set-token');
 
@@ -182,8 +175,7 @@ class SlackChannelTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_the_route_notification_for_slack_method_does_not_provide_a_token_and_the_config_does_not_either(): void
+    public function test_it_throws_an_exception_when_the_route_notification_for_slack_method_does_not_provide_a_token_and_the_config_does_not_either(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Slack API authentication token is not set.');

--- a/tests/Slack/Feature/SlackMessageTest.php
+++ b/tests/Slack/Feature/SlackMessageTest.php
@@ -43,8 +43,7 @@ class SlackMessageTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_no_text_or_block_was_provided(): void
+    public function test_it_throws_an_exception_when_no_text_or_block_was_provided(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Slack messages must contain at least a text message or block.');
@@ -54,8 +53,7 @@ class SlackMessageTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_too_many_blocks_are_defined(): void
+    public function test_it_throws_an_exception_when_too_many_blocks_are_defined(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Slack messages can only contain up to 50 blocks.');
@@ -67,8 +65,7 @@ class SlackMessageTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_sends_a_very_basic_message(): void
+    public function test_it_sends_a_very_basic_message(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('This is a simple Web API text message. See https://api.slack.com/reference/messaging/payload for more information.');
@@ -78,8 +75,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_fails_to_send_a_message_when_the_slack_app_is_not_configured_correctly(): void
+    public function test_it_fails_to_send_a_message_when_the_slack_app_is_not_configured_correctly(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slack API call failed with error [invalid_auth].');
@@ -94,8 +90,7 @@ class SlackMessageTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_set_the_default_channel_for_the_message(): void
+    public function test_it_can_set_the_default_channel_for_the_message(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -106,8 +101,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_use_an_emoji_as_the_icon_for_the_message(): void
+    public function test_it_can_use_an_emoji_as_the_icon_for_the_message(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -119,8 +113,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_use_an_image_as_the_icon_for_the_message(): void
+    public function test_it_can_use_an_image_as_the_icon_for_the_message(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -132,8 +125,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_include_metadata(): void
+    public function test_it_can_include_metadata(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -148,8 +140,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_disable_slack_markdown_parsing(): void
+    public function test_it_can_disable_slack_markdown_parsing(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -161,8 +152,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_unfurl_links(): void
+    public function test_it_can_unfurl_links(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -174,8 +164,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_unfurl_media(): void
+    public function test_it_can_unfurl_media(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -187,8 +176,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_reply_as_thread(): void
+    public function test_it_can_reply_as_thread(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -200,8 +188,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_send_threaded_reply_as_broadcast_reference(): void
+    public function test_it_can_send_threaded_reply_as_broadcast_reference(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -213,8 +200,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_set_the_bot_user_name(): void
+    public function test_it_can_set_the_bot_user_name(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -226,8 +212,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_contains_both_blocks_and_a_fallback_text_used_in_notifications_only(): void
+    public function test_it_contains_both_blocks_and_a_fallback_text_used_in_notifications_only(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->text('This is now a fallback text used in notifications. See https://api.slack.com/methods/chat.postMessage for more information.');
@@ -243,8 +228,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_contain_action_blocks(): void
+    public function test_it_can_contain_action_blocks(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->actionsBlock(function (ActionsBlock $actions) {
@@ -271,8 +255,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_contain_context_blocks(): void
+    public function test_it_can_contain_context_blocks(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->contextBlock(function (ContextBlock $context) {
@@ -295,8 +278,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_contain_divider_blocks(): void
+    public function test_it_can_contain_divider_blocks(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->dividerBlock();
@@ -310,8 +292,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_contain_header_blocks(): void
+    public function test_it_can_contain_header_blocks(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->headerBlock('Budget Performance');
@@ -329,8 +310,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_contain_image_blocks(): void
+    public function test_it_can_contain_image_blocks(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->imageBlock('http://placekitten.com/500/500', function (ImageBlock $imageBlock) {
@@ -348,8 +328,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_contain_section_blocks(): void
+    public function test_it_can_contain_section_blocks(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->sectionBlock(function (SectionBlock $sectionBlock) {
@@ -369,8 +348,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_add_blocks_conditionally(): void
+    public function test_it_can_add_blocks_conditionally(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->when(true, function (SlackMessage $message) {
@@ -411,8 +389,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_submits_blocks_in_the_order_they_were_defined(): void
+    public function test_it_submits_blocks_in_the_order_they_were_defined(): void
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->headerBlock('Budget Performance');
@@ -448,8 +425,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_use_copied_block_kit_template()
+    public function test_it_can_use_copied_block_kit_template()
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->usingBlockKitTemplate(<<<'JSON'
@@ -519,8 +495,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_combined_block_kit_template_and_block_contract_in_order()
+    public function test_it_can_combined_block_kit_template_and_block_contract_in_order()
     {
         $this->sendNotification(function (SlackMessage $message) {
             $message->usingBlockKitTemplate(<<<'JSON'
@@ -574,8 +549,7 @@ class SlackMessageTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_can_return_an_block_kit_builder_url()
+    public function test_it_can_return_an_block_kit_builder_url()
     {
         $message = (new SlackChannelTestNotification(function (SlackMessage $message) {
             $message

--- a/tests/Slack/Unit/Blocks/ActionsBlockTest.php
+++ b/tests/Slack/Unit/Blocks/ActionsBlockTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class ActionsBlockTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $block = new ActionsBlock();
         $block->button('Example Button');
@@ -29,8 +28,7 @@ class ActionsBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_requires_at_least_one_element(): void
+    public function test_it_requires_at_least_one_element(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('There must be at least one element in each actions block.');
@@ -39,8 +37,7 @@ class ActionsBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_does_not_allow_more_than_twenty_five_elements(): void
+    public function test_it_does_not_allow_more_than_twenty_five_elements(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('There is a maximum of 25 elements in each actions block.');
@@ -53,8 +50,7 @@ class ActionsBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_can_manually_specify_the_block_id_field(): void
+    public function test_it_can_manually_specify_the_block_id_field(): void
     {
         $block = new ActionsBlock();
         $block->button('Example Button');
@@ -76,8 +72,7 @@ class ActionsBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_block_id_field_cannot_exceed_255_characters(): void
+    public function test_the_block_id_field_cannot_exceed_255_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the block_id field is 255 characters.');
@@ -89,8 +84,7 @@ class ActionsBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_can_add_buttons(): void
+    public function test_it_can_add_buttons(): void
     {
         $block = new ActionsBlock();
         $block->button('Example Button');
@@ -120,8 +114,7 @@ class ActionsBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_can_add_selects(): void
+    public function test_it_can_add_selects(): void
     {
         $block = new ActionsBlock();
         $block->staticSelect('example select')->id('select_id');

--- a/tests/Slack/Unit/Blocks/ContextBlockTest.php
+++ b/tests/Slack/Unit/Blocks/ContextBlockTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class ContextBlockTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $block = new ContextBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010');
@@ -25,8 +24,7 @@ class ContextBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_requires_at_least_one_element(): void
+    public function test_it_requires_at_least_one_element(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('There must be at least one element in each context block.');
@@ -35,8 +33,7 @@ class ContextBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_does_not_allow_more_than_ten_elements(): void
+    public function test_it_does_not_allow_more_than_ten_elements(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('There is a maximum of 10 elements in each context block.');
@@ -49,8 +46,7 @@ class ContextBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_can_manually_specify_the_block_id_field(): void
+    public function test_it_can_manually_specify_the_block_id_field(): void
     {
         $block = new ContextBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010');
@@ -68,8 +64,7 @@ class ContextBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_block_id_field_cannot_exceed_255_characters(): void
+    public function test_the_block_id_field_cannot_exceed_255_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the block_id field is 255 characters.');
@@ -81,8 +76,7 @@ class ContextBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_can_add_image_blocks(): void
+    public function test_it_can_add_image_blocks(): void
     {
         $block = new ContextBlock();
         $block->image('https://image.freepik.com/free-photo/red-drawing-pin_1156-445.jpg')->alt('images');
@@ -105,8 +99,7 @@ class ContextBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_can_add_text_blocks(): void
+    public function test_it_can_add_text_blocks(): void
     {
         $block = new ContextBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010');

--- a/tests/Slack/Unit/Blocks/DividerBlockTest.php
+++ b/tests/Slack/Unit/Blocks/DividerBlockTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class DividerBlockTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $block = new DividerBlock();
 
@@ -18,8 +17,7 @@ class DividerBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_can_manually_specify_the_block_id_field(): void
+    public function test_it_can_manually_specify_the_block_id_field(): void
     {
         $block = new DividerBlock();
         $block->id('divider1');
@@ -30,8 +28,7 @@ class DividerBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_block_id_field_cannot_exceed_255_characters(): void
+    public function test_the_block_id_field_cannot_exceed_255_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the block_id field is 255 characters.');

--- a/tests/Slack/Unit/Blocks/HeaderBlockTest.php
+++ b/tests/Slack/Unit/Blocks/HeaderBlockTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class HeaderBlockTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $block = new HeaderBlock('Budget Performance');
 
@@ -22,8 +21,7 @@ class HeaderBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_text_heading_cannot_exceed_150_characters(): void
+    public function test_the_text_heading_cannot_exceed_150_characters(): void
     {
         $blockA = new HeaderBlock(str_repeat('a', 151));
         $blockB = new HeaderBlock(str_repeat('b', 150));
@@ -45,8 +43,7 @@ class HeaderBlockTest extends TestCase
         ], $blockB->toArray());
     }
 
-    /** @test */
-    public function it_can_manually_specify_the_block_id_field(): void
+    public function test_it_can_manually_specify_the_block_id_field(): void
     {
         $block = new HeaderBlock('Budget Performance');
         $block->id('header1');
@@ -61,8 +58,7 @@ class HeaderBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_block_id_field_cannot_exceed_255_characters(): void
+    public function test_the_block_id_field_cannot_exceed_255_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the block_id field is 255 characters.');

--- a/tests/Slack/Unit/Blocks/ImageBlockTest.php
+++ b/tests/Slack/Unit/Blocks/ImageBlockTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class ImageBlockTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $block = new ImageBlock('http://placekitten.com/500/500', 'An incredibly cute kitten.');
 
@@ -20,8 +19,7 @@ class ImageBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_url_cannot_exceed_3000_characters(): void
+    public function test_the_url_cannot_exceed_3000_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the url field is 3000 characters.');
@@ -29,8 +27,7 @@ class ImageBlockTest extends TestCase
         new ImageBlock(str_repeat('a', 3001));
     }
 
-    /** @test */
-    public function the_alt_text_is_required(): void
+    public function test_the_alt_text_is_required(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Alt text is required for an image block.');
@@ -40,8 +37,7 @@ class ImageBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function the_alt_text_cannot_exceed_2000_characters(): void
+    public function test_the_alt_text_cannot_exceed_2000_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the alt text field is 2000 characters.');
@@ -52,8 +48,7 @@ class ImageBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_can_have_a_title(): void
+    public function test_it_can_have_a_title(): void
     {
         $block = new ImageBlock('http://placekitten.com/500/500', 'An incredibly cute kitten.');
         $block->title('This one is a cutesy kitten in a box.');
@@ -69,8 +64,7 @@ class ImageBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_title_field_cannot_exceed_2000_characters(): void
+    public function test_the_title_field_cannot_exceed_2000_characters(): void
     {
         $block = new ImageBlock('http://placekitten.com/500/500', 'An incredibly cute kitten.');
         $block->title(str_repeat('a', 2001));
@@ -86,8 +80,7 @@ class ImageBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_can_manually_specify_the_block_id_field(): void
+    public function test_it_can_manually_specify_the_block_id_field(): void
     {
         $block = new ImageBlock('http://placekitten.com/500/500');
         $block->alt('An incredibly cute kitten.');
@@ -101,8 +94,7 @@ class ImageBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_block_id_field_cannot_exceed_255_characters(): void
+    public function test_the_block_id_field_cannot_exceed_255_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the block_id field is 255 characters.');

--- a/tests/Slack/Unit/Blocks/SectionBlockTest.php
+++ b/tests/Slack/Unit/Blocks/SectionBlockTest.php
@@ -9,8 +9,7 @@ use LogicException;
 
 class SectionBlockTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $block = new SectionBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010');
@@ -24,8 +23,7 @@ class SectionBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_no_text_or_field_was_provided(): void
+    public function test_it_throws_an_exception_when_no_text_or_field_was_provided(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('A section requires at least one block, or the text to be set.');
@@ -35,8 +33,7 @@ class SectionBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function the_text_has_a_minimum_length_of_one_character(): void
+    public function test_the_text_has_a_minimum_length_of_one_character(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Text must be at least 1 character(s) long.');
@@ -47,8 +44,7 @@ class SectionBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function the_text_cannot_exceed_3000_characters(): void
+    public function test_the_text_cannot_exceed_3000_characters(): void
     {
         $block = new SectionBlock();
         $block->text(str_repeat('a', 3001));
@@ -62,8 +58,7 @@ class SectionBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_text_can_be_customized(): void
+    public function test_the_text_can_be_customized(): void
     {
         $block = new SectionBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010')->markdown();
@@ -77,8 +72,7 @@ class SectionBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_does_not_allow_more_than_ten_fields(): void
+    public function test_it_does_not_allow_more_than_ten_fields(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('There is a maximum of 10 fields in each section block.');
@@ -91,8 +85,7 @@ class SectionBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function a_field_cannot_exceed_2000_characters(): void
+    public function test_a_field_cannot_exceed_2000_characters(): void
     {
         $block = new SectionBlock();
         $block->field(str_repeat('a', 2001));
@@ -108,8 +101,7 @@ class SectionBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function a_field_can_be_customized(): void
+    public function test_a_field_can_be_customized(): void
     {
         $block = new SectionBlock();
         $block->field('Location: 123 Main Street, New York, NY 10010')->markdown();
@@ -125,8 +117,7 @@ class SectionBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function it_can_manually_specify_the_block_id_field(): void
+    public function test_it_can_manually_specify_the_block_id_field(): void
     {
         $block = new SectionBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010');
@@ -142,8 +133,7 @@ class SectionBlockTest extends TestCase
         ], $block->toArray());
     }
 
-    /** @test */
-    public function the_block_id_field_cannot_exceed_255_characters(): void
+    public function test_the_block_id_field_cannot_exceed_255_characters(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Maximum length for the block_id field is 255 characters.');
@@ -155,8 +145,7 @@ class SectionBlockTest extends TestCase
         $block->toArray();
     }
 
-    /** @test */
-    public function it_can_specify_an_accessory_element(): void
+    public function test_it_can_specify_an_accessory_element(): void
     {
         $block = new SectionBlock();
         $block->text('Location: 123 Main Street, New York, NY 10010');

--- a/tests/Slack/Unit/Composites/ConfirmObjectTest.php
+++ b/tests/Slack/Unit/Composites/ConfirmObjectTest.php
@@ -7,8 +7,7 @@ use Illuminate\Tests\Notifications\Slack\TestCase;
 
 class ConfirmObjectTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $object = new ConfirmObject();
 
@@ -32,8 +31,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_title_field_is_customizable(): void
+    public function test_the_title_field_is_customizable(): void
     {
         $object = new ConfirmObject();
         $object->title('This is a custom title.');
@@ -58,8 +56,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_title_gets_truncated_when_it_exceeds_100_characters(): void
+    public function test_the_title_gets_truncated_when_it_exceeds_100_characters(): void
     {
         $object = new ConfirmObject();
         $object->title(str_repeat('a', 101));
@@ -84,8 +81,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_text_field_is_customizable(): void
+    public function test_the_text_field_is_customizable(): void
     {
         $object = new ConfirmObject();
         $object->text('This is some custom text.');
@@ -110,8 +106,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_text_gets_truncated_when_it_exceeds_300_characters(): void
+    public function test_the_text_gets_truncated_when_it_exceeds_300_characters(): void
     {
         $objectA = new ConfirmObject(str_repeat('a', 301));
 
@@ -157,8 +152,7 @@ class ConfirmObjectTest extends TestCase
         ], $objectB->toArray());
     }
 
-    /** @test */
-    public function the_confirm_field_is_customizable(): void
+    public function test_the_confirm_field_is_customizable(): void
     {
         $object = new ConfirmObject();
         $object->confirm('Custom confirmation button.');
@@ -183,8 +177,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_confirm_field_is_gets_truncated_after_30_characters(): void
+    public function test_the_confirm_field_is_gets_truncated_after_30_characters(): void
     {
         $object = new ConfirmObject();
         $object->confirm(str_repeat('a', 31));
@@ -209,8 +202,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_color_scheme_can_be_set_to_danger(): void
+    public function test_the_color_scheme_can_be_set_to_danger(): void
     {
         $object = new ConfirmObject();
         $object->danger();
@@ -236,8 +228,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_deny_field_is_customizable(): void
+    public function test_the_deny_field_is_customizable(): void
     {
         $object = new ConfirmObject();
         $object->deny('Custom deny button.');
@@ -262,8 +253,7 @@ class ConfirmObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_deny_field_is_gets_truncated_after_30_characters(): void
+    public function test_the_deny_field_is_gets_truncated_after_30_characters(): void
     {
         $object = new ConfirmObject();
         $object->deny(str_repeat('a', 31));

--- a/tests/Slack/Unit/Composites/PlainTextOnlyTextObjectTest.php
+++ b/tests/Slack/Unit/Composites/PlainTextOnlyTextObjectTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class PlainTextOnlyTextObjectTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $object = new PlainTextOnlyTextObject('A message *with some bold text* and _some italicized text_.');
 
@@ -19,8 +18,7 @@ class PlainTextOnlyTextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_text_has_a_minimum_length_of_1_character(): void
+    public function test_the_text_has_a_minimum_length_of_1_character(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Text must be at least 1 character(s) long.');
@@ -28,8 +26,7 @@ class PlainTextOnlyTextObjectTest extends TestCase
         new PlainTextOnlyTextObject('');
     }
 
-    /** @test */
-    public function the_text_gets_truncated_when_it_exceeds_3000_characters(): void
+    public function test_the_text_gets_truncated_when_it_exceeds_3000_characters(): void
     {
         $object = new PlainTextOnlyTextObject(str_repeat('a', 3001));
 
@@ -39,8 +36,7 @@ class PlainTextOnlyTextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function it_can_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format(): void
+    public function test_it_can_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format(): void
     {
         $object = new PlainTextOnlyTextObject('Spooky time! 👻');
         $object->emoji();

--- a/tests/Slack/Unit/Composites/TextObjectTest.php
+++ b/tests/Slack/Unit/Composites/TextObjectTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class TextObjectTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $object = new TextObject('A message *with some bold text* and _some italicized text_.');
 
@@ -19,8 +18,7 @@ class TextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function it_can_be_a_markdown_text_field(): void
+    public function test_it_can_be_a_markdown_text_field(): void
     {
         $object = new TextObject('A message *with some bold text* and _some italicized text_.');
         $object->markdown();
@@ -31,8 +29,7 @@ class TextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function the_text_has_a_minimum_length_of_1_character(): void
+    public function test_the_text_has_a_minimum_length_of_1_character(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Text must be at least 1 character(s) long.');
@@ -40,8 +37,7 @@ class TextObjectTest extends TestCase
         new TextObject('');
     }
 
-    /** @test */
-    public function the_text_gets_truncated_when_it_exceeds_3000_characters(): void
+    public function test_the_text_gets_truncated_when_it_exceeds_3000_characters(): void
     {
         $object = new TextObject(str_repeat('a', 3001));
 
@@ -51,8 +47,7 @@ class TextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function it_can_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format(): void
+    public function test_it_can_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format(): void
     {
         $object = new TextObject('Spooky time! 👻');
         $object->emoji();
@@ -64,8 +59,7 @@ class TextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function it_cannot_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format_when_using_markdown(): void
+    public function test_it_cannot_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format_when_using_markdown(): void
     {
         $object = new TextObject('Spooky time! 👻');
         $object->markdown()->emoji();
@@ -76,8 +70,7 @@ class TextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function it_can_indicate_that_auto_conversion_into_clickable_anchors_should_be_skipped(): void
+    public function test_it_can_indicate_that_auto_conversion_into_clickable_anchors_should_be_skipped(): void
     {
         $object = new TextObject('A message *with some bold text* and _some italicized text_.');
         $object->markdown()->verbatim();
@@ -89,8 +82,7 @@ class TextObjectTest extends TestCase
         ], $object->toArray());
     }
 
-    /** @test */
-    public function it_cannot_indicate_that_auto_conversion_into_clickable_anchors_should_be_skipped_when_using_plaintext(): void
+    public function test_it_cannot_indicate_that_auto_conversion_into_clickable_anchors_should_be_skipped_when_using_plaintext(): void
     {
         $object = new TextObject('A message *with some bold text* and _some italicized text_.');
         $object->verbatim();

--- a/tests/Slack/Unit/Elements/ButtonElementTest.php
+++ b/tests/Slack/Unit/Elements/ButtonElementTest.php
@@ -10,8 +10,7 @@ use InvalidArgumentException;
 
 class ButtonElementTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $element = new ButtonElement('Click Me');
 
@@ -25,8 +24,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_maximum_text_length_is_75_characters(): void
+    public function test_the_maximum_text_length_is_75_characters(): void
     {
         $element = new ButtonElement(str_repeat('a', 250));
 
@@ -40,8 +38,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_text_can_be_customized(): void
+    public function test_the_text_can_be_customized(): void
     {
         $element = new ButtonElement('Click Me', function (PlainTextOnlyTextObject $textObject) {
             $textObject->emoji();
@@ -58,8 +55,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_action_id_can_be_customized(): void
+    public function test_the_action_id_can_be_customized(): void
     {
         $element = new ButtonElement('Click Me');
         $element->id('custom_action_id');
@@ -74,8 +70,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_action_id_cannot_exceed_255_characters(): void
+    public function test_the_action_id_cannot_exceed_255_characters(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Maximum length for the action_id field is 255 characters.');
@@ -86,8 +81,7 @@ class ButtonElementTest extends TestCase
         $element->toArray();
     }
 
-    /** @test */
-    public function it_can_have_an_url(): void
+    public function test_it_can_have_an_url(): void
     {
         $element = new ButtonElement('Click Me');
         $element->url('https://laravel.com');
@@ -103,8 +97,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_url_cannot_exceed_3000_characters(): void
+    public function test_the_url_cannot_exceed_3000_characters(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Maximum length for the url field is 3000 characters.');
@@ -115,8 +108,7 @@ class ButtonElementTest extends TestCase
         $element->toArray();
     }
 
-    /** @test */
-    public function it_can_have_a_value(): void
+    public function test_it_can_have_a_value(): void
     {
         $element = new ButtonElement('Click Me');
         $element->value('click_me_123');
@@ -132,8 +124,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_value_cannot_exceed_2000_characters(): void
+    public function test_the_value_cannot_exceed_2000_characters(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Maximum length for the value field is 2000 characters.');
@@ -144,8 +135,7 @@ class ButtonElementTest extends TestCase
         $element->toArray();
     }
 
-    /** @test */
-    public function it_can_have_the_primary_style(): void
+    public function test_it_can_have_the_primary_style(): void
     {
         $element = new ButtonElement('Click Me');
         $element->primary();
@@ -161,8 +151,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function it_can_have_the_danger_style(): void
+    public function test_it_can_have_the_danger_style(): void
     {
         $element = new ButtonElement('Click Me');
         $element->danger();
@@ -178,8 +167,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function it_can_have_a_confirmation_dialog(): void
+    public function test_it_can_have_a_confirmation_dialog(): void
     {
         $element = new ButtonElement('Click Me');
         $element->confirm('This will do some thing.')->deny('Yikes!');
@@ -212,8 +200,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function it_can_scope_the_confirmation_dialog_and_set_multiple_options(): void
+    public function test_it_can_scope_the_confirmation_dialog_and_set_multiple_options(): void
     {
         $element = new ButtonElement('Click Me');
         $element->confirm('This will do some thing.', function (ConfirmObject $dialog) {
@@ -249,8 +236,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function it_can_have_an_accessibility_label(): void
+    public function test_it_can_have_an_accessibility_label(): void
     {
         $element = new ButtonElement('Click Me');
         $element->accessibilityLabel('Click Me Button');
@@ -266,8 +252,7 @@ class ButtonElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_accessibility_label_cannot_exceed_75_characters(): void
+    public function test_the_accessibility_label_cannot_exceed_75_characters(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Maximum length for the accessibility label is 75 characters.');

--- a/tests/Slack/Unit/Elements/ImageElementTest.php
+++ b/tests/Slack/Unit/Elements/ImageElementTest.php
@@ -8,8 +8,7 @@ use LogicException;
 
 class ImageElementTest extends TestCase
 {
-    /** @test */
-    public function it_is_arrayable(): void
+    public function test_it_is_arrayable(): void
     {
         $element = new ImageElement('http://placekitten.com/700/500', 'Multiple cute kittens');
 
@@ -20,8 +19,7 @@ class ImageElementTest extends TestCase
         ], $element->toArray());
     }
 
-    /** @test */
-    public function the_alt_text_is_required(): void
+    public function test_the_alt_text_is_required(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Alt text is required for an image element.');
@@ -31,8 +29,7 @@ class ImageElementTest extends TestCase
         $element->toArray();
     }
 
-    /** @test */
-    public function the_alt_text_is_optional_during_object_instantiation(): void
+    public function test_the_alt_text_is_optional_during_object_instantiation(): void
     {
         $element = new ImageElement('http://placekitten.com/700/500');
         $element->alt('Some alt text');

--- a/tests/Slack/Unit/Elements/Selects/StaticSelectElementTest.php
+++ b/tests/Slack/Unit/Elements/Selects/StaticSelectElementTest.php
@@ -7,7 +7,6 @@ use Illuminate\Tests\Notifications\Slack\TestCase;
 
 class StaticSelectElementTest extends TestCase
 {
-    /** @test */
     public function test_it_can_add_initial_option(): void
     {
         $select = new StaticSelectElement();
@@ -37,7 +36,6 @@ class StaticSelectElementTest extends TestCase
         ], $select->toArray());
     }
 
-    /** @test */
     public function test_it_can_enable_focus_on_load(): void
     {
         $select = new StaticSelectElement();
@@ -52,7 +50,6 @@ class StaticSelectElementTest extends TestCase
         ], $select->toArray());
     }
 
-    /** @test */
     public function test_it_rejects_invalid_placeholder_text(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -63,7 +60,6 @@ class StaticSelectElementTest extends TestCase
         $select->placeholder('');
     }
 
-    /** @test */
     public function test_it_can_add_multiple_options(): void
     {
         $select = new StaticSelectElement();
@@ -101,7 +97,6 @@ class StaticSelectElementTest extends TestCase
         ], $select->toArray());
     }
 
-    /** @test */
     public function test_it_can_set_placeholder(): void
     {
         $select = new StaticSelectElement();
@@ -119,7 +114,6 @@ class StaticSelectElementTest extends TestCase
         ], $select->toArray());
     }
 
-    /** @test */
     public function test_it_can_disable_focus_on_load(): void
     {
         $select = new StaticSelectElement();
@@ -134,7 +128,6 @@ class StaticSelectElementTest extends TestCase
         ], $select->toArray());
     }
 
-    /** @test */
     public function test_it_rejects_initial_option_when_no_options_available(): void
     {
         $this->expectException(\LogicException::class);

--- a/tests/SlackNotificationRouterChannelTest.php
+++ b/tests/SlackNotificationRouterChannelTest.php
@@ -14,8 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class SlackNotificationRouterChannelTest extends TestCase
 {
-    /** @test */
-    public function it_routes_the_notification_to_the_webhook_channel_when_the_notifiable_route_is_a_string_url(): void
+    public function test_it_routes_the_notification_to_the_webhook_channel_when_the_notifiable_route_is_a_string_url(): void
     {
         $app = new Container();
         $app->bind(SlackWebhookChannel::class, fn () => new FakeSlackChannel(function ($notifiable, $notification) {
@@ -30,8 +29,7 @@ class SlackNotificationRouterChannelTest extends TestCase
         $channel->send(new SlackChannelTestNotifiable('http://example.com'), new SlackChannelTestNotification());
     }
 
-    /** @test */
-    public function it_routes_the_notification_to_the_webhook_channel_when_the_notifiable_route_is_a_psr_url_instance(): void
+    public function test_it_routes_the_notification_to_the_webhook_channel_when_the_notifiable_route_is_a_psr_url_instance(): void
     {
         $app = new Container();
         $app->bind(SlackWebhookChannel::class, fn () => new FakeSlackChannel(function ($notifiable, $notification) {
@@ -46,8 +44,7 @@ class SlackNotificationRouterChannelTest extends TestCase
         $channel->send(new SlackChannelTestNotifiable(new Uri('foo')), new SlackChannelTestNotification());
     }
 
-    /** @test */
-    public function it_routes_the_notification_to_the_web_api_channel_when_the_notifiable_route_is_not_an_url(): void
+    public function test_it_routes_the_notification_to_the_web_api_channel_when_the_notifiable_route_is_not_an_url(): void
     {
         $app = new Container();
         $app->bind(SlackWebhookChannel::class, fn () => new FakeSlackChannel(function () {
@@ -62,8 +59,7 @@ class SlackNotificationRouterChannelTest extends TestCase
         $channel->send(new SlackChannelTestNotifiable('#general'), new SlackChannelTestNotification());
     }
 
-    /** @test */
-    public function it_stops_sending_when_the_notifiable_route_is_false(): void
+    public function test_it_stops_sending_when_the_notifiable_route_is_false(): void
     {
         $app = new Container();
         $app->bind(SlackWebhookChannel::class, fn () => new FakeSlackChannel(function () {


### PR DESCRIPTION
This adds 13.x support, I couldn't upgrade cause of this one package which is pretty good going :D 

- Updated the yml to support Laravel 13, and actually test 13
-  Updates a bunch of composer bits to support the latest versions
- Updated the checkout action while I was here
- Migrated test methods from using `@test` annotations to `test_` prefix for PHPUnit 10+ compatibility (keeping `@dataProvider` alongside `#[DataProvider]` for 9 compatibility)


I havent dropped Laravel 9/10 from the yml though it is EOL. Leaving that up to you guys 🫡  i'm happy to do it in a separate PR tho  just shout 