### PR TITLE
Truncate text objects without splitting multibyte characters

### DIFF
--- a/src/Slack/BlockKit/Composites/PlainTextOnlyTextObject.php
+++ b/src/Slack/BlockKit/Composites/PlainTextOnlyTextObject.php
@@ -27,7 +27,7 @@ class PlainTextOnlyTextObject implements ObjectContract
         }
 
         if (strlen($text) > $maxLength) {
-            $text = substr($text, 0, $maxLength - 3).'...';
+            $text = mb_strcut($text, 0, $maxLength - 3, 'UTF-8').'...';
         }
 
         $this->text = $text;

--- a/tests/Slack/Unit/Composites/PlainTextOnlyTextObjectTest.php
+++ b/tests/Slack/Unit/Composites/PlainTextOnlyTextObjectTest.php
@@ -36,6 +36,18 @@ class PlainTextOnlyTextObjectTest extends TestCase
         ], $object->toArray());
     }
 
+    public function test_truncating_does_not_split_multibyte_characters(): void
+    {
+        // 🪓 is 4 bytes in UTF-8, so the byte-based truncation point lands
+        // mid-character; truncating there must not produce invalid UTF-8.
+        $object = new PlainTextOnlyTextObject(str_repeat('🪓', 751));
+
+        $text = $object->toArray()['text'];
+
+        $this->assertTrue(mb_check_encoding($text, 'UTF-8'));
+        $this->assertNotFalse(json_encode($object->toArray()));
+    }
+
     public function test_it_can_indicate_that_emojis_should_be_escaped_into_the_colon_emoji_format(): void
     {
         $object = new PlainTextOnlyTextObject('Spooky time! 👻');


### PR DESCRIPTION
`PlainTextOnlyTextObject` truncates text over the byte limit with `substr()`, which can cut in the middle of a multibyte character and leave invalid UTF-8. When the message is sent, the HTTP client fails to JSON-encode the payload and throws:

> GuzzleHttp\Exception\InvalidArgumentException: json_encode error: Malformed UTF-8 characters, possibly incorrectly encoded

Switches the truncation to `mb_strcut()`, which keeps the same byte budget but never splits a multibyte character. ASCII behaviour is unchanged.