### PR TITLE
allow guzzlehttp/guzzle 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.0|^8.0",
         "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0"


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows Guzzle HTTP 8.0. All tests continue to pass on this release.